### PR TITLE
Results Implementation Feature for HashMaps

### DIFF
--- a/src/manager/HashableManager.java
+++ b/src/manager/HashableManager.java
@@ -79,4 +79,6 @@ public interface HashableManager<T extends DataType> {
      * Resets the {@link counter.OperationCounter}
      */
     void resetCounter();
+
+    T searchById(T theData);
 }

--- a/src/manager/HashableManager.java
+++ b/src/manager/HashableManager.java
@@ -81,4 +81,10 @@ public interface HashableManager<T extends DataType> {
     void resetCounter();
 
     T searchById(T theData);
+
+    double getLoadFactor();
+
+    int getCollisions();
+
+    void resetCollisions();
 }

--- a/src/manager/MapManager.java
+++ b/src/manager/MapManager.java
@@ -87,6 +87,7 @@ public abstract class MapManager <T extends DataType> implements HashableManager
         }
     }
 
+
     @Override
     public T searchById(T theDataToFind) {
        return myMap.get(theDataToFind.id());
@@ -97,16 +98,29 @@ public abstract class MapManager <T extends DataType> implements HashableManager
         myMap.clear();
     }
 
+    @Override
     public int getSwaps() {
         return myMap.getSwaps();
     }
 
-
+    @Override
     public int getComparisons() {
         return myMap.getComparisons();
     }
 
+    @Override
     public void resetCounter() {
         myMap.resetCounter();
+    }
+
+    @Override
+    public int getCollisions() {return myMap.getCollisions();}
+
+    @Override
+    public void resetCollisions() {myMap.resetCollisions();}
+
+    @Override
+    public double getLoadFactor() {
+        return myMap.loadFactor();
     }
 }

--- a/src/manager/MapManager.java
+++ b/src/manager/MapManager.java
@@ -88,6 +88,11 @@ public abstract class MapManager <T extends DataType> implements HashableManager
     }
 
     @Override
+    public T searchById(T theDataToFind) {
+       return myMap.get(theDataToFind.id());
+    }
+
+    @Override
     public void clearData() {
         myMap.clear();
     }

--- a/src/manager/PlayerManager.java
+++ b/src/manager/PlayerManager.java
@@ -1,18 +1,11 @@
 package manager;
 
-import com.sun.jdi.Value;
-import types.Drill;
-import types.Player;
 import types.PlayerEnhanced;
 import types.Position;
 import util.*;
 
-import java.util.Comparator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.PriorityQueue;
-import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 /**
  * Manages Seahawks Players -update stats yards injury status etc.
@@ -102,7 +95,6 @@ public final class PlayerManager extends MapManager<PlayerEnhanced> {
                 count++;
             }
         }
-
         return count;
     }
 
@@ -130,6 +122,11 @@ public final class PlayerManager extends MapManager<PlayerEnhanced> {
         return table;
     }
 
+    /**
+     * get the total yards for a specific posiiton.
+     * @param position the {@link Position} of the player eg QB, TE, etc.
+     * @return the total yards for playrs with the matching position.
+     */
     public int getTotalYardsByPosition(Position position) {
 
         HashTable<Position, Integer> table = computeTotalYardsByPosition();

--- a/src/results/BenchmarkResult.java
+++ b/src/results/BenchmarkResult.java
@@ -1,9 +1,51 @@
 package results;
 
-public record BenchmarkResult(
-        int inputSize,
-        String method,
-        double avgTime,
-        OperationCounts operationCounts){
+public class BenchmarkResult {
+
+    private final int myInputSize;
+    private final String myMethodName;
+    private final double myAvgTime;
+    private final OperationCounts myOperationCounts;
+    private double myLoadFactor;
+
+    public BenchmarkResult(  int inputSize,
+                             String method,
+                             double avgTime,
+                             OperationCounts operationCounts){
+
+        myInputSize = inputSize;
+        myMethodName = method;
+        myAvgTime = avgTime;
+        myOperationCounts = operationCounts;
+    }
+
+    public void setLoadFactor(double theLoadFactor) {
+        myLoadFactor = theLoadFactor;
+    }
+
+    public double getMyLoadFactor() {
+        return myLoadFactor;
+    }
+
+    public int getInputSize() {
+        return myInputSize;
+    }
+
+    public double getAvgTime() {
+        return myAvgTime;
+    }
+
+    public String getMethodName() {
+        return myMethodName;
+    }
+
+    public int getComparions() {
+        return myOperationCounts.comparisons();
+    }
+
+    public int getSwaps() {
+        return myOperationCounts.swaps();
+    }
+
 
 }

--- a/src/results/BenchmarkResult.java
+++ b/src/results/BenchmarkResult.java
@@ -1,5 +1,6 @@
 package results;
 
+
 public class BenchmarkResult {
 
     private final int myInputSize;
@@ -7,7 +8,15 @@ public class BenchmarkResult {
     private final double myAvgTime;
     private final OperationCounts myOperationCounts;
     private double myLoadFactor;
+    private int myCollisions;
 
+    /**
+     * Creates a new result object with core performance metrics.
+     * @param inputSize The number of elements processed.
+     * @param method The name of the operation (e.g., "Insert", "Search").
+     * @param avgTime The average execution time in milliseconds.
+     * @param operationCounts The captured comparison and swap counts.
+     */
     public BenchmarkResult(  int inputSize,
                              String method,
                              double avgTime,
@@ -19,11 +28,19 @@ public class BenchmarkResult {
         myOperationCounts = operationCounts;
     }
 
+    public int getMyCollisions() {
+        return myCollisions;
+    }
+
+    public void setCollisions(int theCollisions) {
+        myCollisions = theCollisions;
+    }
+
     public void setLoadFactor(double theLoadFactor) {
         myLoadFactor = theLoadFactor;
     }
 
-    public double getMyLoadFactor() {
+    public double getLoadFactor() {
         return myLoadFactor;
     }
 

--- a/src/results/ExperimentFormat.java
+++ b/src/results/ExperimentFormat.java
@@ -8,5 +8,6 @@ package results;
  */
 public enum ExperimentFormat {
     BENCHMARK_NO_OPS,
-    BENCHMARK_W_OPS
+    BENCHMARK_W_OPS,
+    BENCHMARK_MAP
 }

--- a/src/results/ExperimentResults.java
+++ b/src/results/ExperimentResults.java
@@ -1,4 +1,0 @@
-package results;
-
-public class ExperimentResults {
-}

--- a/src/results/FanTicketResults.java
+++ b/src/results/FanTicketResults.java
@@ -39,11 +39,11 @@ public class FanTicketResults extends Results<FanRequest, FanTicketQueue> {
 
 
      int inputSize = myManager.getData().size();
-     String testTitle = enqueue.method() + "/" + dequeue.method();
-     double avgTime = (enqueue.avgTime() + dequeue.avgTime()) / 2.0;
+     String testTitle = enqueue.getMethodName() + "/" + dequeue.getMethodName();
+     double avgTime = (enqueue.getAvgTime() + dequeue.getAvgTime()) / 2.0;
 
-     //@TODO: maybe we should be taking the average of the two operations counts?
-     return new BenchmarkResult(inputSize, testTitle, avgTime, enqueue.operationCounts());
+     OperationCounts operationCounts =  new OperationCounts(myManager.getSwaps(), myManager.getComparisons());
+     return new BenchmarkResult(inputSize, testTitle, avgTime, operationCounts);
     }
 
     @Override

--- a/src/results/HashTableBenchMark.java
+++ b/src/results/HashTableBenchMark.java
@@ -95,12 +95,13 @@ public abstract class HashTableBenchMark<T extends DataType, M extends HashableM
     }
 
     public void ensureManagerContainerNotEmpty() {
-        if (myManager.getData().isEmpty()) {
+        if (myManager.getData().isEmpty() || myManager.getData().size() != myTestContainer.size()) {
             throw new RuntimeException(
                     """
                             Misconfigured Experiment:
                             Please ensure to call setUpForRemove
-                            before conducting removal experiments.
+                            before conducting removal experiments or
+                            searh experiments
                             """
             );
         }
@@ -232,8 +233,21 @@ public abstract class HashTableBenchMark<T extends DataType, M extends HashableM
         return new BenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
     }
 
+    public BenchmarkResult testSearch(String theOperationName, Runnable theSearchTask) {
+        final int inputSize = myManager.getData().size();
+        this.setUpForSearch();
+        final double avgTime =
+                myBenchmarkRunner.runSpeedTestWithSetup(
+                        TRIAL_RUNS,
+                        myManager::resetCounter,
+                        theSearchTask);
+
+        return new BenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
+    }
+
     private OperationCounts getOpCounts() {
         return new OperationCounts(myManager.getSwaps(), myManager.getComparisons());
+
     }
 
     //========================= Displaying Results =================================

--- a/src/results/HashTableBenchMark.java
+++ b/src/results/HashTableBenchMark.java
@@ -119,10 +119,23 @@ public abstract class HashTableBenchMark<T extends DataType, M extends HashableM
         }
     }
 
+    private void ensureCollisionReset() {
+        if (myManager.getCollisions() != 0 ) {
+            throw new RuntimeException(
+                    """
+                            Misconfigured Experiment:
+                            Please ensure to reset collission counts
+                            between experiments.
+                            """
+            );
+        }
+    }
+
     public void validateStateBeforeAddTest() {
         ensureTestContainerNotEmpty();
         ensureManagerContainerEmpty();
         ensureOperationCounterReset();
+        ensureCollisionReset();
     }
 
     public void validateStateBeforeRemoveTest() {
@@ -144,8 +157,7 @@ public abstract class HashTableBenchMark<T extends DataType, M extends HashableM
      * This must be called before every Add experiment.
      */
     public void setUpForAdd() {
-        myManager.clearData();
-        myManager.resetCounter();
+        myManager.clearData(); // <--- this also resets collisions and operation counts
         validateStateBeforeAddTest();
     }
 
@@ -165,10 +177,16 @@ public abstract class HashTableBenchMark<T extends DataType, M extends HashableM
     }
 
     public void setUpForSearch() {
-        for (T dataObj : myTestContainer) {
-            myManager.addData(dataObj);
+        // check if manager test container is empty first
+        if (myManager.getData().isEmpty()) {
+            // if it is, populate it with data to search.
+            for (T dataObj : myTestContainer) {
+                myManager.addData(dataObj);
+            }
         }
+        // reset counter
         myManager.resetCounter();
+        // validate state
         validateStateBeforeSearch();
     }
 
@@ -214,7 +232,7 @@ public abstract class HashTableBenchMark<T extends DataType, M extends HashableM
                         this::setUpForAdd,
                         this::addNTimes);
 
-        return new BenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
+        return createBenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
     }
 
     /**
@@ -230,21 +248,42 @@ public abstract class HashTableBenchMark<T extends DataType, M extends HashableM
                         this::setUpForRemove,
                         this::removeNTimes);
 
-        return new BenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
+        return createBenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
     }
 
+    /**
+     *
+     * @param theOperationName the name of operation - this will end up as the title for the benchmark result
+     * @param theSearchTask the search task to perform for benchmark testing.
+     * @return an {@link BenchmarkResult} that contains benchmark test result metrics - avg time, input size, etc.
+     */
     public BenchmarkResult testSearch(String theOperationName, Runnable theSearchTask) {
         final int inputSize = myManager.getData().size();
         this.setUpForSearch();
         final double avgTime =
                 myBenchmarkRunner.runSpeedTestWithSetup(
                         TRIAL_RUNS,
-                        myManager::resetCounter,
+                        myManager::resetCounter, // reset operation counter for each trial run.
                         theSearchTask);
-
-        return new BenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
+        // report result, note operation counts should be the same across trials
+        // so the final result is the only one we measure.
+        return createBenchmarkResult(inputSize, theOperationName, avgTime, getOpCounts());
     }
 
+    private BenchmarkResult createBenchmarkResult(int inputSize,
+                                                  String theOperationName,
+                                                  double avgTime,
+                                                  OperationCounts operationCounts) {
+        BenchmarkResult result = new BenchmarkResult(inputSize, theOperationName, avgTime, operationCounts);
+        result.setLoadFactor(myManager.getLoadFactor());
+        result.setCollisions(myManager.getCollisions());
+        return result;
+    }
+
+    /**
+     *
+     * @return {@link OperationCounts} - contains information on the
+     */
     private OperationCounts getOpCounts() {
         return new OperationCounts(myManager.getSwaps(), myManager.getComparisons());
 

--- a/src/results/OperationCounts.java
+++ b/src/results/OperationCounts.java
@@ -1,7 +1,13 @@
 package results;
 
+/**
+ *
+ * @param swaps the number of swaps perfomred for a benchmark test
+ * @param comparisons the number of comparisons perfomred for a benchmark test
+ * @author Chris Chun, Ayush.
+ * @version 1.1
+ */
 public record OperationCounts(
         int swaps,
         int comparisons){
-
 }

--- a/src/results/OperationCounts.java
+++ b/src/results/OperationCounts.java
@@ -1,5 +1,7 @@
 package results;
 
-public record OperationCounts(int swaps,int comparisons){
+public record OperationCounts(
+        int swaps,
+        int comparisons){
 
 }

--- a/src/results/PlayerResults.java
+++ b/src/results/PlayerResults.java
@@ -3,6 +3,8 @@ package results;
 import manager.HashableManager;
 import manager.PlayerManager;
 import types.PlayerEnhanced;
+import types.Position;
+import util.Entry;
 
 import java.io.IOException;
 
@@ -12,35 +14,46 @@ public final class PlayerResults extends HashTableBenchMark<PlayerEnhanced, Play
     final static  String PLAYER_500 = "data/seahawks_players_500.csv";
     final static String PLAYER_5000 = "data/seahawks_players_5000.csv";
 
+    private final  PlayerEnhanced notFindable = new PlayerEnhanced(1001,
+            "Not findable", Position.QB,
+            1,1,false);
+
+
     public PlayerResults(
             PlayerManager theManager,
             ExperimentFormat theExperimentFormat){
         super(PlayerEnhanced.class, theManager,theExperimentFormat);
     }
 
+    /**
+     * Searches a hash table of size n, n times for an
+     * item that does not exist.
+     */
+    public void searchNTimes() {
+        for (int i = 0; i < myTestContainer.size(); i++) {
+            myManager.searchById(notFindable);
+        }
+    }
+
 
     @Override
     public void runAllExperiments() throws IOException {
 
-        // Drill 50;
-        loadData(PLAYER_50);
-        addExperimentResult(testAdd("add"));
-        addExperimentResult(testRemove("remove"));
-        // Drill 500;
-        loadData(PLAYER_500);
-        addExperimentResult(testAdd("add"));
-        addExperimentResult(testRemove("remove"));
-        // Drill 5000;
-        loadData(PLAYER_5000);
-        addExperimentResult(testAdd("add"));
-        addExperimentResult(testRemove("remove"));
+        String[] csvFiles = {PLAYER_50, PLAYER_500, PLAYER_5000};
+
+        for (String csvFile : csvFiles) {
+            loadData(csvFile);
+            addExperimentResult(testAdd("Insert"));
+            addExperimentResult(testSearch("Search", this::searchNTimes));
+            addExperimentResult(testRemove("Remove"));
+        }
 
         printResults();
     }
 
     public static void main(String[] args) throws IOException {
         PlayerManager PM = new PlayerManager();
-        PlayerResults results = new PlayerResults(PM, ExperimentFormat.BENCHMARK_NO_OPS);
+        PlayerResults results = new PlayerResults(PM, ExperimentFormat.BENCHMARK_W_OPS);
         results.runAllExperiments();
     }
 

--- a/src/results/PlayerResults.java
+++ b/src/results/PlayerResults.java
@@ -53,7 +53,7 @@ public final class PlayerResults extends HashTableBenchMark<PlayerEnhanced, Play
 
     public static void main(String[] args) throws IOException {
         PlayerManager PM = new PlayerManager();
-        PlayerResults results = new PlayerResults(PM, ExperimentFormat.BENCHMARK_W_OPS);
+        PlayerResults results = new PlayerResults(PM, ExperimentFormat.BENCHMARK_MAP);
         results.runAllExperiments();
     }
 

--- a/src/results/Results.java
+++ b/src/results/Results.java
@@ -329,9 +329,9 @@ public abstract class Results<T extends DataType, M extends Manager<T>>
     public void logExperiment(BenchmarkResult theResult) {
 
         String row;
-        int inputSize = theResult.inputSize();
-        String operationName = theResult.method();
-        double avgTime = theResult.avgTime();
+        int inputSize = theResult.getInputSize();
+        String operationName = theResult.getMethodName();
+        double avgTime = theResult.getAvgTime();
         switch (myExperimentFormat) {
 
             case BENCHMARK_W_OPS ->
@@ -339,8 +339,8 @@ public abstract class Results<T extends DataType, M extends Manager<T>>
                     inputSize,
                     operationName,
                     avgTime,
-                    theResult.operationCounts().comparisons(),
-                    theResult.operationCounts().swaps()
+                    theResult.getComparions(),
+                    theResult.getSwaps()
                     );
 
             case BENCHMARK_NO_OPS ->

--- a/src/results/ResultsDisplay.java
+++ b/src/results/ResultsDisplay.java
@@ -57,9 +57,9 @@ public class ResultsDisplay {
     public void logExperiment(BenchmarkResult theResult) {
 
         String row;
-        int inputSize = theResult.inputSize();
-        String operationName = theResult.method();
-        double avgTime = theResult.avgTime();
+        int inputSize = theResult.getInputSize();
+        String operationName = theResult.getMethodName();
+        double avgTime = theResult.getAvgTime();
         switch (myFormat) {
 
             case BENCHMARK_W_OPS ->
@@ -67,8 +67,8 @@ public class ResultsDisplay {
                             inputSize,
                             operationName,
                             avgTime,
-                            theResult.operationCounts().comparisons(),
-                            theResult.operationCounts().swaps()
+                            theResult.getComparions(),
+                            theResult.getSwaps()
                     );
 
             case BENCHMARK_NO_OPS ->

--- a/src/results/ResultsDisplay.java
+++ b/src/results/ResultsDisplay.java
@@ -70,7 +70,14 @@ public class ResultsDisplay {
                             theResult.getComparions(),
                             theResult.getSwaps()
                     );
-
+            case BENCHMARK_MAP ->
+                    row = String.format("%-10s %-15s %-15.6f %-15s %-10s",
+                            inputSize,
+                            operationName,
+                            avgTime,
+                            theResult.getLoadFactor(),
+                            theResult.getMyCollisions()
+                    );
             case BENCHMARK_NO_OPS ->
                     row = String.format("%-10s %-15s %-15.6f",
                             inputSize,
@@ -92,6 +99,12 @@ public class ResultsDisplay {
                             "Operation",
                             "Avg Time (ms)",
                             "comparisons", "swaps");
+            case BENCHMARK_MAP -> columnHeader =
+                    String.format("%-10s %-15s %-15s %-15s %-10s",
+                            "Size",
+                            "Operation",
+                            "Avg Time (ms)",
+                            "Load Factor", "Collisions");
             case BENCHMARK_NO_OPS -> columnHeader =
                     String.format("%-10s %-15s %-15s%n",
                             "Size",
@@ -107,7 +120,7 @@ public class ResultsDisplay {
             case BENCHMARK_NO_OPS -> {
                 return "========== Benchmark Results ==========";
             }
-            case BENCHMARK_W_OPS -> {
+            case BENCHMARK_W_OPS, BENCHMARK_MAP-> {
                 return "====================== Benchmark Results ======================";
             }
             case null, default -> {
@@ -122,7 +135,7 @@ public class ResultsDisplay {
             case BENCHMARK_NO_OPS -> {
                 return "========================================\n";
             }
-            case BENCHMARK_W_OPS -> {
+            case BENCHMARK_W_OPS, BENCHMARK_MAP-> {
                 return "===============================================================";
             }
             case null, default -> {
@@ -137,7 +150,7 @@ public class ResultsDisplay {
             case BENCHMARK_NO_OPS -> {
                 return "----------------------------------------";
             }
-            case BENCHMARK_W_OPS -> {
+            case BENCHMARK_W_OPS, BENCHMARK_MAP -> {
                 return "---------------------------------------------------------------";
             }
             case null, default -> {

--- a/src/results/UndoResults.java
+++ b/src/results/UndoResults.java
@@ -40,8 +40,8 @@ public class UndoResults extends Results<Action, UndoManager> {
         BenchmarkResult push = this.testAdd("push");
         BenchmarkResult pop = this.testRemove("pop");
 
-        String title = pop.method() + "/" + push.method();
-        double avgTime = (push.avgTime() + pop.avgTime())/ 2.0;
+        String title = pop.getMethodName() + "/" + push.getMethodName();
+        double avgTime = (push.getAvgTime() + pop.getAvgTime())/ 2.0;
         int inputSize = myManager.getData().size();
 
         return new BenchmarkResult(inputSize, title, avgTime, getOpCounts());

--- a/src/util/HashTable.java
+++ b/src/util/HashTable.java
@@ -30,7 +30,7 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
 
     /**
      * HashTable's load factor = size/capcity
-     * resize when load factor > 0.5
+     * resize when load factor > LOAD_FACTOR_TOLLERANCE
      */
     private double myLoadFactor;
 
@@ -40,6 +40,10 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
     private int size;
 
     private final OperationCounter myCounter = new OperationCounter();
+
+    private int myCollissions;
+
+    private static final double LOAD_FACTOR_TOLLERANCE = 0.75;
 
 
     /**
@@ -103,6 +107,7 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
         // if it is not empty iterate over all entries in the bucket
         // and return it if present.
         for (Entry<K,V> entry: bucketList) {
+            myCounter.increment("comparisons");
             if (Objects.equals(entry.key(), key)) {
                 return entry.value();
             }
@@ -125,18 +130,31 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
         // 3) add the new Entry to the linked list at the hash index.
         SinglyLinkedList<Entry<K,V>> tableListEntry = myTable.get(hashIndex);
 
-        // a) first check if the entry is already in the list and update it if it
-        // is there.
+        // a) check if bucket is empty
+        if (tableListEntry.isEmpty()) {
+            size++;
+            tableListEntry.addFront(theNewEntry);
+            updateLoadLoadFactor();
+            if (myLoadFactor > LOAD_FACTOR_TOLLERANCE) {
+                resize();
+            }
+        } else
+            // b) check if the entry already existis and update if it does.
         if (!wasAbleToUpdateListEntry(tableListEntry, theNewEntry) ) {
-            // b) otherwise add the entry to the front of the bucket list.
+
+            // c) otherwise add the entry to the front of the bucket list.
             tableListEntry.addFront(theNewEntry);
             //4) update size only when the new entry is not already present.
             size++;
             //5) update load factor
             updateLoadLoadFactor();
 
-            //6) resize if necessary
-            if (myLoadFactor > 0.5) {
+            //7) if we got mapped to the same bucket but equality was determined
+            // to not be equal then it means a collission has occured
+            myCollissions++;
+
+            //8) resize if necessary
+            if (myLoadFactor > LOAD_FACTOR_TOLLERANCE) {
                 resize();
             }
         }
@@ -171,6 +189,7 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
         SinglyLinkedList<Entry<K,V>> bucketList = myTable.get(bucketIndex);
 
         for (Entry<K,V> entry: bucketList) {
+            myCounter.increment("comparisons");
             if (Objects.equals(entry.key(), key)) {
                 return true;
             }
@@ -264,6 +283,7 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
             Entry<K,V> theNewEntry) {
 
         for (Entry<K,V>  currentEntry : tableListEntry) {
+            myCounter.increment("comparisons");
             if (Objects.equals(theNewEntry.key(),currentEntry.key())) {
                 currentEntry.setEntry(theNewEntry.value());
                 return true;
@@ -275,14 +295,13 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
     private void resize() {
         HashTable<K,V> temp = new HashTable<>(myKeyClass, myValueClass, myTable.size()*2);
 
-        Iterator<Entry<K,V>> iterator = iterator();
-
-        while(iterator.hasNext()) {
-            Entry<K,V> entry = iterator.next();
+        for (Entry<K, V> entry : this) {
             temp.put(entry.key(), entry.value());
         }
 
         myTable = temp.myTable;
+        myCounter.increment("comparisons", temp.getComparisons());
+        myCollissions += temp.getCollissons();
         myLoadFactor = temp.loadFactor();
         size = temp.size;
     }
@@ -300,5 +319,13 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
     @Override
     public void resetCounter() {
         myCounter.resetAll();
+    }
+
+    public int getCollissons() {
+        return myCollissions;
+    }
+
+    public void restCollisions() {
+        myCollissions = 0;
     }
 }

--- a/src/util/HashTable.java
+++ b/src/util/HashTable.java
@@ -41,9 +41,11 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
 
     private final OperationCounter myCounter = new OperationCounter();
 
-    private int myCollissions;
+    private int myCollisions;
 
     private static final double LOAD_FACTOR_TOLLERANCE = 0.75;
+
+    private static final int DEFAULT_CAPCITY = 16;
 
 
     /**
@@ -54,7 +56,7 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
      */
     public HashTable(Class<K> theKeyClass, Class<V> theValueClass) {
 
-        this(theKeyClass,  theValueClass, 16);
+        this(theKeyClass,  theValueClass, DEFAULT_CAPCITY);
     }
 
     /**
@@ -151,7 +153,7 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
 
             //7) if we got mapped to the same bucket but equality was determined
             // to not be equal then it means a collission has occured
-            myCollissions++;
+            myCollisions++;
 
             //8) resize if necessary
             if (myLoadFactor > LOAD_FACTOR_TOLLERANCE) {
@@ -239,6 +241,8 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
         int curCapacity = myTable.size();
         myTable.clear();
         size = 0;
+        myCounter.resetAll();
+        resetCollisions();
         initializeHashTable(myTable, curCapacity);
     }
 
@@ -301,7 +305,7 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
 
         myTable = temp.myTable;
         myCounter.increment("comparisons", temp.getComparisons());
-        myCollissions += temp.getCollissons();
+        myCollisions += temp.getCollisions();
         myLoadFactor = temp.loadFactor();
         size = temp.size;
     }
@@ -321,11 +325,11 @@ public final class HashTable<K,V> implements Dictionary<K,V>, Iterable<Entry<K,V
         myCounter.resetAll();
     }
 
-    public int getCollissons() {
-        return myCollissions;
+    public int getCollisions() {
+        return myCollisions;
     }
 
-    public void restCollisions() {
-        myCollissions = 0;
+    public void resetCollisions() {
+        myCollisions = 0;
     }
 }


### PR DESCRIPTION
- Updated HashTableBenchMark abstract class with the ability to run search tests for Dictionary (HashMap) data structures.
- Created new Enum for test types to accomodate for PA5 feature requirements of displaying collision and load factor calculations across experiments.
- Modified contract of Dicitonay interface to guarantee access to telemetry data such as collision counts, load factor, operation counts, i.e., swaps and comparisons
- Updated HashTable class to correctly calculate the number of collisions and comparisons 
- TODO: need to create PA5 results table comparing efficiency in algorithmic operations of search, add, remove across Arrays, LinkedLists, and HashTables.  